### PR TITLE
Camelize variables names format option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.1
+  - Add camelized variables names format option
+
 ## 1.1.0
   - Add support for protobuf3
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ reports, or in general have helped logstash along its way.
 Contributors:
 * Inga Feick (ingafeick)
 * Nicolai Schulten (krakenfuss)
+* Gregory Ferreux (gferreux)
 
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.1.0'
+  s.version         = '1.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
add an option to camelize variables names, camelize function, and camelize hashes key, to be able to get camelCase format fields in elasticsearch