### PR TITLE
Add length-delimited option to encoder and decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.3
+  - Add length-delimited feature to decoder and encoder
 ## 1.2.2
   - Add type conversion feature to encoder
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ There are two ways to specify the locations of the ruby protobuf definitions:
 
 `pb3_encoder_autoconvert_types` (optional): Encoder only: will try to fix type mismatches between the protobuf definition and the actual data. Available for protobuf 3 only. Activated by default.
 
+`length_delimited` (optional): Each message should be delimited with it's length before message data. Defaults to false.
+
 ## Usage example: decoder
 
 Use this as a codec in any logstash input. Just provide the name of the class that your incoming objects will be encoded in, and specify the path to the compiled definition.

--- a/lib/logstash/codecs/protobuf.rb
+++ b/lib/logstash/codecs/protobuf.rb
@@ -203,12 +203,12 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
   end
 
   def decode(data)
+    if length_delimited
+      data = ProtocolBuffers.bin_sio(data)
+      length = ProtocolBuffers::Varint.decode(data)
+      data = LimitedIO.new(data, length).read
+    end
     if @protobuf_version == 3
-      if length_delimited
-        data = ProtocolBuffers.bin_sio(data)
-        length = ProtocolBuffers::Varint.decode(data)
-        data = LimitedIO.new(data, length).read
-      end
       decoded = @pb_builder.decode(data.to_s)
       h = pb3_deep_to_hash(decoded)
     else
@@ -530,7 +530,15 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
   def pb2_encode(event)
     data = pb2_prepare_for_encoding(event.to_hash, @class_name)
     msg = @pb_builder.new(data)
-    msg.serialize_to_string
+    if length_delimited
+      byte_data = msg.serialize_to_string
+      sio = ProtocolBuffers.bin_sio
+      ProtocolBuffers::Varint.encode(sio, byte_data.size)
+      sio.write(byte_data)
+      sio.string
+    else
+      msg.serialize_to_string
+    end
   rescue NoMethodError => e
     @logger.warn("Encoding error 2. Probably mismatching protobuf definition. Required fields in the protobuf definition are: " + event.to_hash.keys.join(", ") + " and the timestamp field name must not include a @. ")
     raise e

--- a/lib/logstash/codecs/protobuf.rb
+++ b/lib/logstash/codecs/protobuf.rb
@@ -204,6 +204,11 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
 
   def decode(data)
     if @protobuf_version == 3
+      if length_delimited
+        data = ProtocolBuffers.bin_sio(data)
+        length = ProtocolBuffers::Varint.decode(data)
+        data = LimitedIO.new(data, length).read
+      end
       decoded = @pb_builder.decode(data.to_s)
       h = pb3_deep_to_hash(decoded)
     else

--- a/lib/logstash/codecs/protobuf.rb
+++ b/lib/logstash/codecs/protobuf.rb
@@ -140,6 +140,8 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
   # Instruct the encoder to attempt converting data types to match the protobuf definitions. Available only for protobuf version 3.
   config :pb3_encoder_autoconvert_types, :validate => :boolean, :default => true, :required => false
 
+  # Each message should be delimited with it's length before message data
+  config :length_delimited, :validate => :boolean, :default => false, :required => false
 
 
   attr_reader :execution_context
@@ -271,7 +273,15 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
       @logger.warn("Protobuf encoding error 5: empty protobuf builder for class #{@class_name}")
     end
     pb_obj = @pb_builder.new(datahash)
-    @pb_builder.encode(pb_obj)
+    if length_delimited
+      byte_data = @pb_builder.encode(pb_obj)
+      sio = ProtocolBuffers.bin_sio
+      ProtocolBuffers::Varint.encode(sio, byte_data.size)
+      sio.write(byte_data)
+      sio.string
+    else
+      @pb_builder.encode(pb_obj)
+    end
 
   rescue ArgumentError => e
     k = event.to_hash.keys.join(", ")

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.2.2'
+  s.version         = '1.2.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Some databases (like [clickhouse](https://clickhouse.yandex/docs/en/interfaces/formats/#protobuf)) just accept length-delimited messages and there isn't any option to send or receive length-delimited messages.
I added an option to support encoding and decoding of length-delimited messages.