### PR TITLE
Check encoder result empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.4
+  - Encoder bugfix: avoid pipeline crash if encoding failed.
+
 ## 1.2.3
   - Add oneof information to @metadata (protobuf version 3 only).
 

--- a/lib/logstash/codecs/protobuf.rb
+++ b/lib/logstash/codecs/protobuf.rb
@@ -295,10 +295,13 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
     k = event.to_hash.keys.join(", ")
     @logger.warn("Protobuf encoding error 1: Argument error (#{e.inspect}). Reason: probably mismatching protobuf definition. \
       Required fields in the protobuf definition are: #{k} and fields must not begin with @ sign. The event has been discarded.")
+    nil
   rescue TypeError => e
     pb3_handle_type_errors(event, e, is_recursive_call, datahash)
+    nil
   rescue => e
     @logger.warn("Protobuf encoding error 3: #{e.inspect}. Event discarded. Input data: #{datahash}. The event has been discarded. Backtrace: #{e.backtrace}")
+    nil
   end
 
 

--- a/lib/logstash/codecs/protobuf.rb
+++ b/lib/logstash/codecs/protobuf.rb
@@ -241,7 +241,9 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
     else
       protobytes = pb2_encode(event)
     end
-    @on_event.call(event, protobytes)
+    unless protobytes.nil? or protobytes.empty?
+      @on_event.call(event, protobytes)
+    end
   end # def encode
 
 

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.2.3'
+  s.version         = '1.2.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/pb3_encode_spec.rb
+++ b/spec/codecs/pb3_encode_spec.rb
@@ -211,5 +211,33 @@ context "encodePB3-e" do
 
 
 
+context "encodePB3-f" do
+
+    #### Test case 5: handle additional fields (discard event without crashing pipeline) ####################################################################################################################
+
+    subject do
+      next LogStash::Codecs::Protobuf.new("class_name" => "something.rum_akamai.ProtoAkamai3Rum",
+        "pb3_encoder_autoconvert_types" => false,
+        "include_path" => [pb_include_path + '/pb3/rum3_pb.rb' ], "protobuf_version" => 3)
+    end
+
+    event = LogStash::Event.new(
+      "domain" => nil, "bot" => "This field does not exist in the protobuf definition",
+      "header" => {"sender_id" => "23"},
+      "geo"=>{"organisation"=>"Jio", "rg"=>"DL", "netspeed"=>nil, "city"=>nil, "cc"=>"IN", "ovr"=>false, "postalcode"=>"110012", "isp"=>"Jio"}
+    )
+
+    it "should not return data" do
+
+      subject.on_event do |event, data|
+        expect("the on_event method should not be called").to eq("so this code should never be reached")
+      end
+      subject.encode(event)
+    end # it
+
+  end # context #encodePB3-f
+
+
+
 
 end # describe


### PR DESCRIPTION
This PR addresses the issue that if the pb encoding fails the pipeline stops. 
In order to reproduce just add a field to the event which is not present in the protobuf definition.


```
[WARN ] 2020-06-10 13:43:38.952 [[rum-akamai2bi]>worker1] protobuf - Protobuf encoding error 1: Argument error (#<ArgumentError: field bot is not found>). Reason: probably mismatching protobuf definition.       Required fields in the protobuf definition are: user_agent, geo, dom, active_ctests, header, timestamp, domain, tracking_id and fields must not begin with @ sign. The event has been discarded.
[ERROR] 2020-06-10 13:43:38.954 [[rum-akamai2bi]>worker1] WorkerLoop - Exception in pipelineworker, the pipeline stopped processing new events, please check your filter configuration and restart Logstash.
org.jruby.exceptions.NoMethodError: (NoMethodError) undefined method `to_java_bytes' for #<LogStash::Logging::Logger:0x57183637>
	at usr.share.logstash.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_output_minus_kafka_minus_8_dot_0_dot_1.lib.logstash.outputs.kafka.register(/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-kafka-8.0.1/lib/logstash/outputs/kafka.rb:195) ~[?:?]
	at usr.share.logstash.vendor.local_gems.$26ab4dac.logstash_minus_codec_minus_protobuf_minus_1_dot_2_dot_2.lib.logstash.codecs.protobuf.encode(/usr/share/logstash/vendor/local_gems/26ab4dac/logstash-codec-protobuf-1.2.2/lib/logstash/codecs/protobuf.rb:228) ~[?:?]
	at usr.share.logstash.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_output_minus_kafka_minus_8_dot_0_dot_1.lib.logstash.outputs.kafka.multi_receive(/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-kafka-8.0.1/lib/logstash/outputs/kafka.rb:217) ~[?:?]
	at org.jruby.RubyArray.each(org/jruby/RubyArray.java:1792) ~[jruby-complete-9.2.7.0.jar:?]
	at usr.share.logstash.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_output_minus_kafka_minus_8_dot_0_dot_1.lib.logstash.outputs.kafka.multi_receive(/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-kafka-8.0.1/lib/logstash/outputs/kafka.rb:215) ~[?:?]
	at org.logstash.config.ir.compiler.OutputStrategyExt$AbstractOutputStrategyExt.multi_receive(org/logstash/config/ir/compiler/OutputStrategyExt.java:118) ~[logstash-core.jar:?]
	at org.logstash.config.ir.compiler.AbstractOutputDelegatorExt.multi_receive(org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java:101) ~[logstash-core.jar:?]
	at usr.share.logstash.logstash_minus_core.lib.logstash.java_pipeline.start_workers(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:235) ~[?:?]
[FATAL] 2020-06-10 13:43:39.065 [LogStash::Runner] runner - An unexpected error occurred! {:error=>java.lang.IllegalStateException: org.jruby.exceptions.NoMethodError: (NoMethodError) undefined method `to_java_bytes' for #<LogStash::Logging::Logger:0x57183637>, :backtrace=>["org.logstash.execution.WorkerLoop.run(org/logstash/execution/WorkerLoop.java:85)", "java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)", "org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:425)", "org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:292)", "usr.share.logstash.logstash_minus_core.lib.logstash.java_pipeline.start_workers(/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:235)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:295)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:274)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:270)", "java.lang.Thread.run(java/lang/Thread.java:748)"]}
```