### PR TITLE
Bugfix: in case of errors return nil instead of @logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.5
+  - Encoder bugfix: avoid pipeline crash if encoding failed.
+
 ## 1.2.4
   - Encoder bugfix: avoid pipeline crash if encoding failed.
 

--- a/lib/logstash/codecs/protobuf.rb
+++ b/lib/logstash/codecs/protobuf.rb
@@ -134,7 +134,7 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
   # Recommendation: use the translate plugin to restore previous behaviour when upgrading.
   config :protobuf_version, :validate => [2,3], :default => 2, :required => true
 
-  # To tolerate faulty messages that cannot be decoded, set this to false. Otherwise the pipeline will stop upon encountering a non decipherable message.
+  # To tolerate faulty messages that cannot be en/decoded, set this to false. Otherwise the pipeline will stop upon encountering a non decipherable message.
   config :stop_on_error, :validate => :boolean, :default => false, :required => false
 
   # Instruct the encoder to attempt converting data types to match the protobuf definitions. Available only for protobuf version 3.
@@ -332,10 +332,19 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
       else
         @logger.warn("Protobuf encoding error 2.4.2: (#{e.inspect}). The event has been discarded.")
       end
+      if @stop_on_error
+        raise e
+      end
+      nil
     rescue => ex
       @logger.warn("Protobuf encoding error 2.5: (#{e.inspect}). The event has been discarded. Auto-typecasting was on: #{@pb3_encoder_autoconvert_types}")
+      if @stop_on_error
+        raise ex
+      end
+      nil
     end
   end # pb3_handle_type_errors
+
 
   def pb3_get_type_mismatches(data, key_prefix, pb_class)
     mismatches = []
@@ -562,7 +571,6 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
     @logger.warn("Encoding error 1: #{e.inspect}")
     raise e
   end
-
 
 
   def pb2_prepare_for_encoding(datahash, class_name)

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.2.4'
+  s.version         = '1.2.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
When the encoder finds incompatible fields (error code 2.5) it returns the @logger object instead of nil. 

```
[WARN ] 2021-02-04 11:31:40.801 [[foo]>worker0] protobuf - Protobuf encoding error 2.5: (#<TypeError: Invalid argument for boolean field.>). 
: true
[ERROR] 2021-02-04 11:31:40.815 [[foo]>worker0] javapipeline - Pipeline worker error, the pipeline will be stopped {:pipeline_id=>"foo", :error=>"(NoMethodError) undefined method `to_java_bytes' for #<LogStash::Logging::Logger:0x108c71bc>", :exception=>Java::OrgJrubyExceptions::NoMethodError, ...
```