### PR TITLE
Doc: Fix link format

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -224,7 +224,10 @@ Available only for protobuf version 3.
   * Value type is <<boolean,boolean>>
   * Default value is false
 
-Add meta information to `[@metadata][pb_oneof]` about which classes were chosen for [oneof](https://developers.google.com/protocol-buffers/docs/proto3#oneof) fields. A new field of name `[@metadata][pb_oneof][FOO]` will be added, where `FOO` is the name of the `oneof` field.
+Add meta information to `[@metadata][pb_oneof]` about which classes were chosen
+for https://developers.google.com/protocol-buffers/docs/proto3#oneof[oneof]
+fields. A new field of name `[@metadata][pb_oneof][FOO]` will be added, where
+`FOO` is the name of the `oneof` field.
 
 Example values: for the protobuf definition
 [source,ruby]


### PR DESCRIPTION
Format link using asciidoc link syntax
