### PR TITLE
Syntax change to support protobuf gems > 3.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a codec plugin for [Logstash](https://github.com/elastic/logstash) to pa
 * install the codec: `bin/logstash-plugin install logstash-codec-protobuf`
 * use the codec in your Logstash config file. See details below.
 
-Note: the latest supported jruby version of Google's protobuf library is 3.0.5.pre. If you need to use a more current version, please find instructions in [this issue](https://github.com/logstash-plugins/logstash-codec-protobuf/issues/62).
+Note: the latest supported jruby version of Google's protobuf library is 3.5.0.pre. If you need to use a more current version, please find instructions [here](google-protobuf-lib-update.md).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a codec plugin for [Logstash](https://github.com/elastic/logstash) to pa
 * install the codec: `bin/logstash-plugin install logstash-codec-protobuf`
 * use the codec in your Logstash config file. See details below.
 
-Note: the latest supported jruby version of Google's protobuf library is 3.0.5pre. If you need to use a more current version, please find instructions in [this issue](https://github.com/logstash-plugins/logstash-codec-protobuf/issues/62).
+Note: the latest supported jruby version of Google's protobuf library is 3.0.5.pre. If you need to use a more current version, please find instructions in [this issue](https://github.com/logstash-plugins/logstash-codec-protobuf/issues/62).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This is a codec plugin for [Logstash](https://github.com/elastic/logstash) to pa
 * install the codec: `bin/logstash-plugin install logstash-codec-protobuf`
 * use the codec in your Logstash config file. See details below.
 
+Note: the latest supported jruby version of Google's protobuf library is 3.0.5pre. If you need to use a more current version, please find instructions in [this issue](https://github.com/logstash-plugins/logstash-codec-protobuf/issues/62).
+
 ## Configuration
 
 There are two ways to specify the locations of the ruby protobuf definitions:

--- a/google-protobuf-lib-update.md
+++ b/google-protobuf-lib-update.md
@@ -1,0 +1,35 @@
+The google protobuf gem has [not been updated for jruby in a while](https://github.com/protocolbuffers/protobuf/issues/1594) and is currently only available in version [3.0.5pre](https://rubygems.org/gems/google-protobuf/versions/3.5.0.pre-java) whereas the official protobuf version is 3.18+.
+If you want to use a newer library version then please follow these instructions on how to manually build the google-protobuf.gem.
+
+0.  Get the protobuf sources:
+```
+git clone https://github.com/protocolbuffers/protobuf.git;
+cd protobuf;
+git checkout $VERSION_YOU_WANT_TO_BUILD
+```
+
+1. Check your compiler version. It needs to be at least the version that you want to build for.
+`protoc --version`
+
+If your compiler is too old, build it from the repo:
+
+```
+git submodule update --init --recursive
+./autogen.sh
+./configure
+make
+make check
+sudo make install
+```
+
+(instructions taken from their [src/README.md](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md) - check for updates in there!)
+
+2. Build the gem:
+`cd ruby; rake build && gem build *.gemspec`
+
+(Instructions taken from https://github.com/protocolbuffers/protobuf/issues/1594#issuecomment-258029377)
+
+3. Install the new gem in your Logstash:
+```
+logstash-plugin install --no-verify google-protobuf-$PROTOBUF_GEM_VERSION-java.gem
+```

--- a/google-protobuf-lib-update.md
+++ b/google-protobuf-lib-update.md
@@ -1,4 +1,4 @@
-The google protobuf gem has [not been updated for jruby in a while](https://github.com/protocolbuffers/protobuf/issues/1594) and is currently only available in version [3.0.5pre](https://rubygems.org/gems/google-protobuf/versions/3.5.0.pre-java) whereas the official protobuf version is 3.18+.
+The google protobuf gem has [not been updated for jruby in a while](https://github.com/protocolbuffers/protobuf/issues/1594) and is currently only available in version [3.0.5.pre](https://rubygems.org/gems/google-protobuf/versions/3.5.0.pre-java) whereas the official protobuf version is 3.18+.
 If you want to use a newer library version then please follow these instructions on how to manually build the google-protobuf.gem.
 
 0.  Get the protobuf sources:

--- a/google-protobuf-lib-update.md
+++ b/google-protobuf-lib-update.md
@@ -29,9 +29,27 @@ sudo make install
 
 (Instructions taken from https://github.com/protocolbuffers/protobuf/issues/1594#issuecomment-258029377)
 
-3. Install the new gem in your Logstash:
+3. Change the dependency in the protobuf codec:
+
+Step 3.a: clone this repo.
+`git clone git@github.com:logstash-plugins/logstash-codec-protobuf.git`
+
+Step 3.b: edit the dependency in [the gemspec](https://github.com/logstash-plugins/logstash-codec-protobuf/blob/master/logstash-codec-protobuf.gemspec#L23) to the version that you built in step 2.
+
+Step 3.c: set the [codec version in the gemspec](https://github.com/logstash-plugins/logstash-codec-protobuf/blob/master/logstash-codec-protobuf.gemspec#L4) to a number that is not available on rubygems.
+
+Step 3.d: build the codec. `rake build && gem build logstash-codec-protobuf.gemspec`
+
+
+4. Install both gems in your Logstash (in this order):
 ```
 logstash-plugin install --no-verify google-protobuf-$PROTOBUF_GEM_VERSION-java.gem
+logstash-plugin install logstash-codec-protobuf-$PROTOBUF_INPUT_PLUGIN_VERSION.gem
 ```
 
-4. Make sure that you use at least version 1.2.6 or higher of the logstash-codec-protobuf.
+# Notes
+
+We experimented with both the `>= ` and the `~>` operators in the dependency specification, such as
+` s.add_runtime_dependency 'google-protobuf', '>= 3.5.0.pre`
+but it would always lead to the ruby version of the protobuf gem to be pulled. Hints / PRs for pinning this to the Java/Jruby version would be appreciated and would render the steps in section 3 and parts of step 4 unnecessary.
+

--- a/google-protobuf-lib-update.md
+++ b/google-protobuf-lib-update.md
@@ -1,4 +1,4 @@
-The google protobuf gem has [not been updated for jruby in a while](https://github.com/protocolbuffers/protobuf/issues/1594) and is currently only available in version [3.0.5.pre](https://rubygems.org/gems/google-protobuf/versions/3.5.0.pre-java) whereas the official protobuf version is 3.18+.
+The google protobuf gem has [not been updated for jruby in a while](https://github.com/protocolbuffers/protobuf/issues/1594) and is currently only available in version [3.5.0.pre](https://rubygems.org/gems/google-protobuf/versions/3.5.0.pre-java) whereas the official protobuf version is 3.18+.
 If you want to use a newer library version then please follow these instructions on how to manually build the google-protobuf.gem.
 
 0.  Get the protobuf sources:

--- a/google-protobuf-lib-update.md
+++ b/google-protobuf-lib-update.md
@@ -33,3 +33,5 @@ sudo make install
 ```
 logstash-plugin install --no-verify google-protobuf-$PROTOBUF_GEM_VERSION-java.gem
 ```
+
+4. Make sure that you use at least version 1.2.6 or higher of the logstash-codec-protobuf.

--- a/lib/logstash/codecs/protobuf.rb
+++ b/lib/logstash/codecs/protobuf.rb
@@ -252,7 +252,7 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
     case input
     when Google::Protobuf::MessageExts # it's a protobuf class
       result = Hash.new
-      input.to_hash.each {|key, value|
+      input.to_h.each {|key, value|
         result[key] = pb3_deep_to_hash(value) # the key is required for the class lookup of enums.
       }
     when ::Array
@@ -339,7 +339,7 @@ class LogStash::Codecs::Protobuf < LogStash::Codecs::Base
 
   def pb3_get_type_mismatches(data, key_prefix, pb_class)
     mismatches = []
-    data.to_hash.each do |key, value|
+    data.to_h.each do |key, value|
         expected_type = pb3_get_expected_type(key, pb_class)
         r = pb3_compare_datatypes(value, key, key_prefix, pb_class, expected_type)
         mismatches.concat(r)

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.2.6'
+  s.version         = '1.2.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'google-protobuf', '3.5.0.pre' # has been tested with 3.17.3
+  s.add_runtime_dependency 'google-protobuf', '>= 3.5.0.pre' # has been tested with 3.17.3
   s.add_runtime_dependency 'ruby-protocol-buffers' # for protobuf 2
   s.add_development_dependency 'logstash-devutils'
 

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.authors         = ["Inga Feick"]
   s.email           = 'inga.feick@trivago.com'
   s.require_paths   = ["lib"]
+  s.platform        = "jruby"
 
   # Files
   s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]
@@ -20,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'google-protobuf', '>= 3.5.0.pre' # has been tested with 3.17.3
+  s.add_runtime_dependency 'google-protobuf', '3.5.0.pre' # set this to your custom library version if you want
   s.add_runtime_dependency 'ruby-protocol-buffers' # for protobuf 2
   s.add_development_dependency 'logstash-devutils'
 

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.2.4'
+  s.version         = '1.2.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'google-protobuf', '3.5.0.pre'
+  s.add_runtime_dependency 'google-protobuf', '3.5.0.pre' # has been tested with 3.17.3
   s.add_runtime_dependency 'ruby-protocol-buffers' # for protobuf 2
   s.add_development_dependency 'logstash-devutils'
 


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

The google protobuf gem has [not been updated for jruby in a while](https://github.com/protocolbuffers/protobuf/issues/1594) and is currently only available in version [3.0.5pre](https://rubygems.org/gems/google-protobuf/versions/3.5.0.pre-java) whereas the official protobuf version is 3.18+. This commit adresses issue https://github.com/logstash-plugins/logstash-codec-protobuf/issues/62  in that it introduces a minor syntax change which makes the codec compatible with newer versions of the google-protobuf gem. Instructions on how to build said gem can be found at https://github.com/logstash-plugins/logstash-codec-protobuf/issues/62#issuecomment-929069437. 

This version of the codec has been tested with the google-protobuf gem versions 3.0.5pre and 3.17.3.

## Why is it important/What is the impact to the user?

Users might need some of the features or changes introduced in protobuf versions > 3.0.5. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable)

## How to test this PR locally

See instructions in google-protobuf-lib-update.md

## Related issues

- Closes #62 
