### PR TITLE
Update pb lib to 3.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.8
+  - Update protobuf library to 3.22.2
+
+## 1.2.7
+  - TODO
+
 ## 1.2.6
   - [DOC] Fixed link format (from MD to asciidoc) [#61](https://github.com/logstash-plugins/logstash-codec-protobuf/pull/61)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a codec plugin for [Logstash](https://github.com/elastic/logstash) to pa
 * install the codec: `bin/logstash-plugin install logstash-codec-protobuf`
 * use the codec in your Logstash config file. See details below.
 
-Note: the latest supported jruby version of Google's protobuf library is 3.5.0.pre. If you need to use a more current version, please find instructions [here](google-protobuf-lib-update.md).
+Note: the latest supported jruby version of Google's protobuf library is 3.22.2. If you need to use a more current version, please find instructions [here](google-protobuf-lib-update.md).
 
 ## Configuration
 

--- a/google-protobuf-lib-update.md
+++ b/google-protobuf-lib-update.md
@@ -1,5 +1,7 @@
-The google protobuf gem has [not been updated for jruby in a while](https://github.com/protocolbuffers/protobuf/issues/1594) and is currently only available in version [3.5.0.pre](https://rubygems.org/gems/google-protobuf/versions/3.5.0.pre-java) whereas the official protobuf version is 3.18+.
-If you want to use a newer library version then please follow these instructions on how to manually build the google-protobuf.gem.
+# Custom google protobuf library version
+
+At the time of this writing, the codec uses the [protoc library version 3.22.2](https://rubygems.org/gems/google-protobuf/versions/3.22.2-java).
+If you want to use a different protobuf library version then please follow these instructions on how to manually build the google-protobuf.gem.
 
 0.  Get the protobuf sources:
 ```

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.2.7'
+  s.version         = '1.2.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'google-protobuf', '3.5.0.pre' # set this to your custom library version if you want
+  s.add_runtime_dependency 'google-protobuf', '3.22.2' # for protobuf 3
   s.add_runtime_dependency 'ruby-protocol-buffers' # for protobuf 2
   s.add_development_dependency 'logstash-devutils'
 


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Update the `google-protobuf` library to 3.22.2

## Why is it important/What is the impact to the user?

The current version of the library is outdated.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
