### PR TITLE
Update gem platform to be "java" instead of "jruby"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.11
+  - Update gem platform to be "java" instead of "jruby" [#67](https://github.com/logstash-plugins/logstash-codec-protobuf/pull/67)
+
 ## 1.2.9
   - Fix decoding of structs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.11
+## 1.2.10
   - Update gem platform to be "java" instead of "jruby" [#67](https://github.com/logstash-plugins/logstash-codec-protobuf/pull/67)
 
 ## 1.2.9

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.2.10'
+  s.version         = '1.2.11'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,14 +1,14 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.2.9'
+  s.version         = '1.2.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Inga Feick"]
   s.email           = 'inga.feick@trivago.com'
   s.require_paths   = ["lib"]
-  s.platform        = "jruby"
+  s.platform        = "java"
 
   # Files
   s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]

--- a/logstash-codec-protobuf.gemspec
+++ b/logstash-codec-protobuf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-protobuf'
-  s.version         = '1.2.11'
+  s.version         = '1.2.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads protobuf messages and converts to Logstash Events"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
It seems like rubygems is inconsistent in handling java vs jruby platforms in gems https://github.com/rubygems/rubygems/issues/2140#issuecomment-358359378

With JRuby 9.3 and bundler 2.4, bundler will fail to find versions of this gem > 1.2.5 with a 403 forbidden error:

```
Using logstash-core-plugin-api 2.1.28 (java)
Fetching logstash-codec-protobuf 1.2.9 (java)

Retrying download gem from https://rubygems.org/ due to error (2/4): Gem::RemoteFetcher::FetchError bad response Forbidden 403 (https://rubygems.org/gems/logstash-codec-protobuf-1.2.9-java.gem)

Retrying download gem from https://rubygems.org/ due to error (3/4): Gem::RemoteFetcher::FetchError bad response Forbidden 403 (https://rubygems.org/gems/logstash-codec-protobuf-1.2.9-java.gem)

Retrying download gem from https://rubygems.org/ due to error (4/4): Gem::RemoteFetcher::FetchError bad response Forbidden 403 (https://rubygems.org/gems/logstash-codec-protobuf-1.2.9-java.gem)

Bundler::HTTPError: Could not download gem from https://rubygems.org/ due to
underlying error <bad response Forbidden 403
(https://rubygems.org/gems/logstash-codec-protobuf-1.2.9-java.gem)>
```

This is preventing this gem to be installed in Logstash versions 8.8.0+ (8.7.x had bundler 2.3).